### PR TITLE
Fixed deprecation error

### DIFF
--- a/frontmark/__init__.py
+++ b/frontmark/__init__.py
@@ -1,8 +1,8 @@
-import pelican.signals
+from pelican import signals as pelican_signals
 
 from .__about__ import __version__, __description__  # noqa
 from .reader import add_reader
 
 
 def register():
-    pelican.signals.readers_init.connect(add_reader)
+    pelican_signals.readers_init.connect(add_reader)


### PR DESCRIPTION
* direct import of pelican.signals not allowed anymore switched as proposed
* import with alias to pervent ambigiouty with local signals.py